### PR TITLE
(wip) [feature] add DB setup, skeletal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ cache: apt
 
 install:
 - go get github.com/gorilla/mux
+- go get github.com/kelseyhightower/envconfig
+- go get gopkg.in/mgo.v2
 
 before_script:
 

--- a/app.go
+++ b/app.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/gobbl/bouncer/controllers"
+	"github.com/gobbl/bouncer/models"
 	"github.com/gorilla/mux"
 )
 
@@ -49,6 +50,9 @@ func main() {
 	flag.Parse()
 
 	r := setupServer()
+
+	models.Start()
+	defer models.Close()
 
 	fmt.Printf("Starting server on port:%d", port)
 	http.ListenAndServe(fmt.Sprintf(":%d", port), r)

--- a/models/helpers.go
+++ b/models/helpers.go
@@ -1,0 +1,63 @@
+package models
+
+import (
+	"strings"
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	"gopkg.in/mgo.v2"
+)
+
+type mongoConfiguration struct {
+	Hosts    string
+	Database string
+	UserName string
+	Password string
+}
+
+type mongoSession struct {
+	dialInfo *mgo.DialInfo
+	session  *mgo.Session
+}
+
+var singleton mongoSession
+
+const (
+	dbEnvPrefix = "benri"
+)
+
+func Start() error {
+	if singleton.dialInfo != nil {
+		return nil
+	}
+	var cfg mongoConfiguration
+	// read from env var
+	if err := envconfig.Process(dbEnvPrefix, &cfg); err != nil {
+		return err
+	}
+
+	hosts := strings.Split(cfg.Hosts, ",")
+
+	// setup with singleton
+	singleton := mongoSession{
+		dialInfo: &mgo.DialInfo{
+			Addrs:    hosts,
+			Timeout:  60 * time.Second,
+			Database: cfg.Database,
+			Username: cfg.UserName,
+			Password: cfg.Password,
+		},
+	}
+
+	mongoSession, err := mgo.DialWithInfo(singleton.dialInfo)
+	if err != nil {
+		return err
+	}
+	singleton.session = mongoSession
+	singleton.session.SetSafe(&mgo.Safe{})
+	return nil
+}
+
+func Close() {
+	singleton.session.Close()
+}

--- a/models/users.go
+++ b/models/users.go
@@ -1,0 +1,3 @@
+package models
+
+// TODO


### PR DESCRIPTION
This PR adds a setup for DB sessions with the `mgo` library so that we can pull user info from our mongoDB database.
### note

all database config (e.g., database name, password) are assumed in as environment variables
### todo
- [ ] add tests
- [ ] add endpoint(s) to fetch restaurants/ user models for testing of DB connection 
